### PR TITLE
답변 페이지 기능 완료 + 화면 이동 오류 수정

### DIFF
--- a/app/src/main/java/com/example/ratemate/home/HomeNavigationBar.kt
+++ b/app/src/main/java/com/example/ratemate/home/HomeNavigationBar.kt
@@ -11,12 +11,15 @@ import androidx.compose.runtime.getValue
 import androidx.navigation.NavController
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.navArgument
 import com.example.ratemate.Store.StoreScreen
 import com.example.ratemate.myPage.MyPageScreen
 import com.example.ratemate.setting.Option
+import com.example.ratemate.survey.AnswerSurveyScreen
 import com.example.ratemate.survey.CreateSurveyScreen
 
 
@@ -26,6 +29,7 @@ sealed class HomeNavRoutes (val route: String) {
     object MyPage : HomeNavRoutes("MyPage")
     object Shop : HomeNavRoutes("Shop")
     object Option : HomeNavRoutes("Option")
+    object AnswerSurvey: HomeNavRoutes("AnswerSurvey")
 }
 
 @Composable
@@ -48,6 +52,19 @@ fun HomeNavigationHost(navController: NavHostController, startnavController: Nav
         }
         composable(HomeNavRoutes.Option.route){
             Option(startnavController)
+        }
+
+        composable(
+            HomeNavRoutes.AnswerSurvey.route + "/{SurveyID}",
+            arguments = listOf(
+                navArgument(name = "SurveyID") {
+                    type = NavType.StringType
+                }
+            )) {
+            AnswerSurveyScreen(
+                navController = navController,
+                surveyId = it.arguments?.getString("SurveyID")
+            )
         }
 
     }

--- a/app/src/main/java/com/example/ratemate/home/HomeNavigationBar.kt
+++ b/app/src/main/java/com/example/ratemate/home/HomeNavigationBar.kt
@@ -30,6 +30,7 @@ sealed class HomeNavRoutes (val route: String) {
     object Shop : HomeNavRoutes("Shop")
     object Option : HomeNavRoutes("Option")
     object AnswerSurvey: HomeNavRoutes("AnswerSurvey")
+    object SurveyResult : HomeNavRoutes("SurveyResult")
 }
 
 @Composable
@@ -64,6 +65,20 @@ fun HomeNavigationHost(navController: NavHostController, startnavController: Nav
             AnswerSurveyScreen(
                 navController = navController,
                 surveyId = it.arguments?.getString("SurveyID")
+            )
+        }
+
+        composable(
+            HomeNavRoutes.SurveyResult.route + "/{SurveyID}",
+            arguments = listOf(
+                navArgument(name = "SurveyID") {
+                    type = NavType.StringType
+                }
+            )
+        ) {
+            SurveyResultScreen(
+                navController = navController,
+                SurveyID = it.arguments?.getString("SurveyID")
             )
         }
 

--- a/app/src/main/java/com/example/ratemate/home/SurveyResultScreen.kt
+++ b/app/src/main/java/com/example/ratemate/home/SurveyResultScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
@@ -80,6 +81,7 @@ import androidx.compose.ui.window.PopupProperties
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.example.ratemate.R
+import com.example.ratemate.common.CommonTopAppBar
 import com.example.ratemate.data.Comment
 import com.example.ratemate.data.Dislike
 import com.example.ratemate.data.Like
@@ -87,11 +89,8 @@ import com.example.ratemate.data.QnA
 import com.example.ratemate.data.Response
 import com.example.ratemate.data.SurveyV2
 import com.example.ratemate.data.User
-import com.example.ratemate.repository.CommentRepository
 import com.example.ratemate.repository.SurveyV2Repository
 import com.example.ratemate.repository.UserRepository
-import com.example.ratemate.viewModel.CommentViewModel
-import com.example.ratemate.viewModel.CommentViewModelFactory
 import com.example.ratemate.viewModel.SurveyV2ViewModel
 import com.example.ratemate.viewModel.SurveyV2ViewModelFactory
 import com.example.ratemate.viewModel.UserViewModel
@@ -389,48 +388,63 @@ fun ShowSurveyResultScreen(user: User, Result : SurveyV2, navController: NavCont
             clickSortByLikes()
         }
 
+        Scaffold(
+            topBar = {
+                CommonTopAppBar(title = "결과", onNavigateBack = { navController.navigate("home") })
+            }
+        ) { paddingValues ->
+            //전체화면 Column
+            Column(
+                modifier = Modifier
+                    .padding(paddingValues)
+                    .fillMaxSize()
+                    .clickable(
+                        onClick = { focusManager.clearFocus() },
+                        indication = null,
+                        interactionSource = remember { MutableInteractionSource() }
+                    ),
 
-        //전체화면 Column
-        Column (
-            modifier = Modifier
-                .fillMaxSize()
-                .clickable(
-                    onClick = { focusManager.clearFocus() },
-                    indication = null,
-                    interactionSource = remember { MutableInteractionSource() }
-                ),
-
-            ){
-
-
-            //제목, 작성자
-            val modifier1 = Modifier.height(40.dp)
-            ShowTitle(title = surveyResult!!.title, writer = surveyResult!!.creatorId,
-                isMySurvey = isMySurvey, modifier = modifier1, editSurvey = editSurvey
-                , removeSurvey = removeSurvey)
-
-            //내용
-            val modifier2 = Modifier.weight(7f)
-            ShowMainContent(content = content, userChoice = userChoice, modifier = modifier2)
-
-            //좋아요, 댓글 수, 댓글 정렬 방법 버튼
-            val modifier3 = Modifier.height(40.dp)
-            ShowCounts(isLiked = isLiked, like = likes,
-                numberOfComment = numberOfComment, modifier = modifier3,
-                clickLikes = clickLikes, clickSortByLikes = clickSortByLikes,
-                clickSortByDate = clickSortByDate)
-
-            //댓글 리스트
-            Divider()
-            val modifier5 = Modifier.weight(5f)
-            ShowComments(user, comments = commentList, surveyResult = surveyResult!!,
-                modifier = modifier5)
-
-            //댓글 입력창
-            val modifier6 = Modifier.height(70.dp)
-            ShowCommentInput(modifier = modifier6, onClickSend = onClickSend)
+                ) {
 
 
+                //제목, 작성자
+                val modifier1 = Modifier.height(40.dp)
+                ShowTitle(
+                    title = surveyResult!!.title,
+                    writer = surveyResult!!.creatorId,
+                    isMySurvey = isMySurvey,
+                    modifier = modifier1,
+                    editSurvey = editSurvey,
+                    removeSurvey = removeSurvey
+                )
+
+                //내용
+                val modifier2 = Modifier.weight(7f)
+                ShowMainContent(content = content, userChoice = userChoice, modifier = modifier2)
+
+                //좋아요, 댓글 수, 댓글 정렬 방법 버튼
+                val modifier3 = Modifier.height(40.dp)
+                ShowCounts(
+                    isLiked = isLiked, like = likes,
+                    numberOfComment = numberOfComment, modifier = modifier3,
+                    clickLikes = clickLikes, clickSortByLikes = clickSortByLikes,
+                    clickSortByDate = clickSortByDate
+                )
+
+                //댓글 리스트
+                Divider()
+                val modifier5 = Modifier.weight(5f)
+                ShowComments(
+                    user, comments = commentList, surveyResult = surveyResult!!,
+                    modifier = modifier5
+                )
+
+                //댓글 입력창
+                val modifier6 = Modifier.height(70.dp)
+                ShowCommentInput(modifier = modifier6, onClickSend = onClickSend)
+
+
+            }
         }
     }
 

--- a/app/src/main/java/com/example/ratemate/myPage/MyPageNavigationBar.kt
+++ b/app/src/main/java/com/example/ratemate/myPage/MyPageNavigationBar.kt
@@ -1,7 +1,6 @@
 package com.example.ratemate.myPage
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
@@ -16,7 +15,6 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.navArgument
 import com.example.ratemate.home.SurveyResultScreen
-import com.example.ratemate.navigation.Route
 
 sealed class MyPageNavRoutes (val route: String) {
     object Quest : MyPageNavRoutes("Quest")

--- a/app/src/main/java/com/example/ratemate/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/ratemate/navigation/NavGraph.kt
@@ -10,8 +10,6 @@ import com.example.ratemate.home.HomeScreen
 import com.example.ratemate.login.LoginScreen
 import com.example.ratemate.login.RegisterScreen
 import com.example.ratemate.login.StartScreen
-import com.example.ratemate.survey.CreateSurveyScreen
-import com.example.ratemate.survey.SurveyResultScreen
 
 sealed class Route(val route: String){
     object Start: Route("Start")
@@ -47,13 +45,6 @@ fun NavGraph(navController: NavHostController, startDestination: Route) {
         }
         composable("Home") {
             HomeScreen(navController)
-        }
-
-        composable(Route.CreateSurvey.route) {
-            CreateSurveyScreen(navController)
-        }
-        composable(Route.SurveyResult.route) {
-            SurveyResultScreen()
         }
     }
 }

--- a/app/src/main/java/com/example/ratemate/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/ratemate/navigation/NavGraph.kt
@@ -10,6 +10,8 @@ import com.example.ratemate.home.HomeScreen
 import com.example.ratemate.login.LoginScreen
 import com.example.ratemate.login.RegisterScreen
 import com.example.ratemate.login.StartScreen
+import com.example.ratemate.survey.CreateSurveyScreen
+import com.example.ratemate.survey.SurveyResultScreen
 
 sealed class Route(val route: String){
     object Start: Route("Start")
@@ -45,6 +47,13 @@ fun NavGraph(navController: NavHostController, startDestination: Route) {
         }
         composable("Home") {
             HomeScreen(navController)
+        }
+
+        composable(Route.CreateSurvey.route) {
+            CreateSurveyScreen(navController)
+        }
+        composable(Route.SurveyResult.route) {
+            SurveyResultScreen()
         }
     }
 }

--- a/app/src/main/java/com/example/ratemate/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/ratemate/navigation/NavGraph.kt
@@ -7,10 +7,10 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.example.ratemate.home.HomeScreen
-import com.example.ratemate.home.SurveyResultScreen
 import com.example.ratemate.login.LoginScreen
 import com.example.ratemate.login.RegisterScreen
 import com.example.ratemate.login.StartScreen
+import com.example.ratemate.survey.AnswerSurveyScreen
 import com.example.ratemate.survey.CreateSurveyScreen
 import com.example.ratemate.survey.ResultScreen
 
@@ -22,6 +22,7 @@ sealed class Route(val route: String){
     object SurveyList: Route("SurveyList")
     object CreateSurvey : Route("CreateSurvey")
     object Result : Route("Result")
+    object AnswerSurvey: Route("AnswerSurvey")
 
 }
 
@@ -63,6 +64,16 @@ fun NavGraph(navController: NavHostController, startDestination: Route) {
         ) { backStackEntry ->
             val surveyId = backStackEntry.arguments?.getString("surveyId")
             ResultScreen(navController = navController, surveyId = surveyId)
+        }
+
+        composable(
+            route = "AnswerSurvey?surveyId={surveyId}",
+            arguments = listOf(
+                navArgument("surveyId") { type = NavType.StringType }
+            )
+        ) { backStackEntry ->
+            val surveyId = backStackEntry.arguments?.getString("surveyId")
+            AnswerSurveyScreen(navController = navController, surveyId = surveyId)
         }
 
 

--- a/app/src/main/java/com/example/ratemate/survey/AnswerSurveyScreen.kt
+++ b/app/src/main/java/com/example/ratemate/survey/AnswerSurveyScreen.kt
@@ -1,6 +1,5 @@
 package com.example.ratemate.survey
 
-import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -22,6 +21,7 @@ import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateMapOf
@@ -32,125 +32,145 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
 import com.example.ratemate.R
 import com.example.ratemate.common.CommonTopAppBar
+import com.example.ratemate.data.QnA
+import com.example.ratemate.repository.SurveyV2Repository
 import com.example.ratemate.ui.theme.NotoSansKr
+import com.example.ratemate.viewModel.SurveyV2ViewModel
+import com.example.ratemate.viewModel.SurveyV2ViewModelFactory
 
 // 답변 화면
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AnswerSurveyScreen(
-    surveyTitle: String,
-    questions: List<QuestionItem>,
-    onSubmit: (Map<String, List<String>>) -> Unit,
-    onNavigateBack: () -> Unit
-) {
+fun AnswerSurveyScreen(navController: NavController, surveyId: String?) {
+    val surveyV2ViewModel: SurveyV2ViewModel = viewModel(factory = SurveyV2ViewModelFactory(SurveyV2Repository()))
+
+    if (surveyId != null) {
+        surveyV2ViewModel.getSurvey(surveyId)
+    }
+
+    val survey by surveyV2ViewModel.survey.collectAsState(initial = null)
+    val isSurveyLoaded by surveyV2ViewModel.isSurveyLoaded.collectAsState()
+
     val answers = remember { mutableStateMapOf<String, MutableList<String>>() }
     var currentPage by remember { mutableStateOf(0) }
 
-    val isLastPage = currentPage == questions.size - 1
+    val isLastPage = currentPage == (survey?.qnA?.size ?: 0) - 1
     val isFirstPage = currentPage == 0
-
-    val allAnswered = answers.size == questions.size && answers.values.all { it.isNotEmpty() }
+    val allAnswered = survey?.qnA?.let { questions ->
+        answers.size == questions.size && answers.values.all { it.isNotEmpty() }
+    } ?: false
 
     Scaffold(
         topBar = {
-            CommonTopAppBar(title = "설문조사", onNavigateBack)
+            CommonTopAppBar(title = "설문조사", onNavigateBack = { navController.popBackStack() })
         }
     ) { paddingValues ->
-        Column(
-            modifier = Modifier
-                .padding(paddingValues)
-                .padding(horizontal = 20.dp)
-                .verticalScroll(rememberScrollState())
-        ) {
-            Text(
-                text = surveyTitle,
-                modifier = Modifier.fillMaxSize(),
-                fontFamily = NotoSansKr,
-                fontWeight = FontWeight.Bold,
-                fontSize = 20.sp
-            )
-
-            Question(questions[currentPage], answers)
-
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 20.dp),
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                Button(
+        if (isSurveyLoaded && survey != null) {
+            survey?.let { surveyData ->
+                Column(
                     modifier = Modifier
-                        .width(168.dp)
-                        .height(40.dp),
-                    onClick = { if (!isFirstPage) currentPage-- },
-                    enabled = !isFirstPage,
-                    colors = ButtonDefaults.buttonColors(
-                        if (isFirstPage) colorResource(id = R.color.gray_400) else colorResource(id = R.color.main_blue)
-                    ),
-                    contentPadding = PaddingValues(vertical = 0.dp)
+                        .padding(paddingValues)
+                        .padding(horizontal = 20.dp)
+                        .verticalScroll(rememberScrollState())
                 ) {
                     Text(
-                        text = "이전",
+                        text = surveyData.title,
+                        modifier = Modifier.fillMaxSize(),
                         fontFamily = NotoSansKr,
-                        fontSize = 14.sp,
                         fontWeight = FontWeight.Bold,
-                        color = if (isFirstPage) colorResource(id = R.color.gray_500) else colorResource(
-                            id = R.color.white
-                        )
+                        fontSize = 20.sp
                     )
-                }
 
-                Button(
-                    modifier = Modifier
-                        .width(168.dp)
-                        .height(40.dp),
-                    onClick = { if (!isLastPage) currentPage++ },
-                    enabled = !isLastPage,
-                    colors = ButtonDefaults.buttonColors(
-                        if (isLastPage) colorResource(id = R.color.gray_400) else colorResource(id = R.color.main_blue)
-                    ),
-                    contentPadding = PaddingValues(vertical = 0.dp)
-                ) {
-                    Text(
-                        text = "다음",
-                        fontFamily = NotoSansKr,
-                        fontSize = 14.sp,
-                        fontWeight = FontWeight.Bold,
-                        color = if (isLastPage) colorResource(id = R.color.gray_500) else colorResource(
-                            id = R.color.white
-                        )
-                    )
+                    Question(surveyData.qnA[currentPage], answers)
+
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 20.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Button(
+                            modifier = Modifier
+                                .width(168.dp)
+                                .height(40.dp),
+                            onClick = { if (!isFirstPage) currentPage-- },
+                            enabled = !isFirstPage,
+                            colors = ButtonDefaults.buttonColors(
+                                if (isFirstPage) colorResource(id = R.color.gray_400) else colorResource(id = R.color.main_blue)
+                            ),
+                            contentPadding = PaddingValues(vertical = 0.dp)
+                        ) {
+                            Text(
+                                text = "이전",
+                                fontFamily = NotoSansKr,
+                                fontSize = 14.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = if (isFirstPage) colorResource(id = R.color.gray_500) else colorResource(id = R.color.white)
+                            )
+                        }
+
+                        Button(
+                            modifier = Modifier
+                                .width(168.dp)
+                                .height(40.dp),
+                            onClick = { if (!isLastPage) currentPage++ },
+                            enabled = !isLastPage,
+                            colors = ButtonDefaults.buttonColors(
+                                if (isLastPage) colorResource(id = R.color.gray_400) else colorResource(id = R.color.main_blue)
+                            ),
+                            contentPadding = PaddingValues(vertical = 0.dp)
+                        ) {
+                            Text(
+                                text = "다음",
+                                fontFamily = NotoSansKr,
+                                fontSize = 14.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = if (isLastPage) colorResource(id = R.color.gray_500) else colorResource(id = R.color.white)
+                            )
+                        }
+                    }
+
+                    if (allAnswered) {
+                        Button(
+                            onClick = { surveyId?.let { navController.navigate("Result/$it") } },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(40.dp),
+                            colors = ButtonDefaults.buttonColors(colorResource(id = R.color.main_blue)),
+                            contentPadding = PaddingValues(vertical = 0.dp)
+                        ) {
+                            Text(
+                                text = "설문조사 제출",
+                                fontFamily = NotoSansKr,
+                                fontSize = 14.sp,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+                    }
                 }
             }
-
-            if (allAnswered) {
-                Button(
-                    onClick = { onSubmit(answers) },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(40.dp),
-                    colors = ButtonDefaults.buttonColors(colorResource(id = R.color.main_blue)),
-                    contentPadding = PaddingValues(vertical = 0.dp)
-                ) {
-                    Text(
-                        text = "설문조사 제출",
-                        fontFamily = NotoSansKr,
-                        fontSize = 14.sp,
-                        fontWeight = FontWeight.Bold
-                    )
-                }
+        } else {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text("Loading...")
             }
         }
     }
 }
 
 @Composable
-fun Question(question: QuestionItem, answers: MutableMap<String, MutableList<String>>) {
+fun Question(question: QnA, answers: MutableMap<String, MutableList<String>>) {
     // 현재 질문에 대해 이미 선택된 답변을 가져옴
     val selectedAnswers = answers.getOrPut(question.question) { mutableStateListOf() }
 
@@ -160,7 +180,7 @@ fun Question(question: QuestionItem, answers: MutableMap<String, MutableList<Str
             fontFamily = NotoSansKr,
             fontSize = 16.sp
         )
-        question.answers.forEach { answer ->
+        question.answerList.forEach { answer ->
             Row(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
@@ -202,28 +222,4 @@ fun Question(question: QuestionItem, answers: MutableMap<String, MutableList<Str
             }
         }
     }
-}
-
-
-@Preview(showBackground = true)
-@Composable
-fun PreviewTakeSurveyScreen() {
-    val sampleQuestions = listOf(
-        QuestionItem("질문1", mutableListOf("답변1-1", "답변1-2", "답변1-3"), "single"),
-        QuestionItem("질문2", mutableListOf("답변2-1", "답변2-2", "답변2-3", "답변2-4", "답변2-5"), "multiple"),
-        QuestionItem(
-            "질문3",
-            mutableListOf("답변3-1", "답변3-2", "답변3-3", "답변3-4", "답변3-5", "답변3-6"),
-            "single"
-        ),
-        QuestionItem("질문4", mutableListOf("답변4-1", "답변4-2", "답변4-3", "답변4-4"), "multiple")
-    )
-    AnswerSurveyScreen(
-        surveyTitle = "사용자 만족도 조사",
-        questions = sampleQuestions,
-        onSubmit = { answers ->
-            Log.d("Submitted answers", answers.toString())
-        },
-        onNavigateBack = { /* Handle navigation back */ }
-    )
 }

--- a/app/src/main/java/com/example/ratemate/survey/CreateSurveyScreen.kt
+++ b/app/src/main/java/com/example/ratemate/survey/CreateSurveyScreen.kt
@@ -68,20 +68,16 @@ fun CreateSurveyScreen(navController: NavHostController) {
     var surveyTitle by remember { mutableStateOf("") }
     val questionsList = remember { mutableStateListOf<QuestionItem>() }
 
-    val onNavigateToResult: (String) -> Unit = { /* Handle navigation to result */ }
-//    val onNavigateBack: () -> Unit = { /* Handle navigation back */ }
-
     var addSurvey by remember { mutableStateOf(false) }
 
-
-    //유저 정보 가져오기
+    // 유저 정보 가져오기
     val auth = FirebaseAuth.getInstance()
-    val userUid = auth.currentUser?.uid?: ""
-    val userViewModel : UserViewModel = viewModel (factory = UserViewModelFactory(UserRepository()))
+    val userUid = auth.currentUser?.uid ?: ""
+    val userViewModel: UserViewModel = viewModel(factory = UserViewModelFactory(UserRepository()))
     userViewModel.getUser(userUid)
     val user by userViewModel.user.collectAsState(initial = null)
 
-    if (user == null){
+    if (user == null) {
         Column(
             modifier = Modifier.fillMaxSize(),
             verticalArrangement = Arrangement.Center,
@@ -89,8 +85,7 @@ fun CreateSurveyScreen(navController: NavHostController) {
         ) {
             Text("Loading...")
         }
-    }
-    else{
+    } else {
         Scaffold(
             topBar = {
                 CommonTopAppBar(title = "등록하기", onNavigateBack = {
@@ -129,8 +124,9 @@ fun CreateSurveyScreen(navController: NavHostController) {
                             questionsList[index] = questionItem.copy(answers = updatedAnswers)
                         },
                         onRemoveQuestion = {
-                            Log.d("index", index.toString())
+                            Log.d("questionList", questionsList.toString())
                             questionsList.removeAt(index)
+                            Log.d("questionList", questionsList.toString())
                         }
                     )
                 }
@@ -188,30 +184,24 @@ fun CreateSurveyScreen(navController: NavHostController) {
                     )
                 }
 
-
-                if (addSurvey){
+                if (addSurvey) {
                     addSurvey = false
 
                     var check by remember { mutableStateOf("success") }
 
-
-                    if (surveyTitle == ""){
+                    if (surveyTitle == "") {
                         check = "제목이 비어있습니다"
-                    }
-                    else if (questionsList.size == 0){
+                    } else if (questionsList.size == 0) {
                         check = "질문이 비어있습니다"
-                    }
-                    else if (questionsList.any { it.question == "" }){
+                    } else if (questionsList.any { it.question == "" }) {
                         check = "질문이 비어있습니다"
-                    }
-                    else if (questionsList.any { it.answers.size < 2 }){
+                    } else if (questionsList.any { it.answers.size < 2 }) {
                         check = "답변이 2개 이상이어야 합니다"
-                    }
-                    else if (questionsList.any { it.answers.any { it == "" } }){
+                    } else if (questionsList.any { it.answers.any { it == "" } }) {
                         check = "답변이 비어있습니다"
                     }
 
-                    if (check == "success"){
+                    if (check == "success") {
                         Toast.makeText(context, "설문조사가 등록되었습니다.", Toast.LENGTH_SHORT).show()
 
                         val surveyData = SurveyV2(
@@ -239,20 +229,13 @@ fun CreateSurveyScreen(navController: NavHostController) {
                         viewModel.addSurvey(surveyData)
                         userViewModel.addSurveyToCreated(userUid, surveyData.surveyId)
                         navController.navigate("home")
-                    }
-                    else {
+                    } else {
                         Toast.makeText(context, check, Toast.LENGTH_SHORT).show()
                     }
-
-
-
                 }
-
-
             }
         }
     }
-
 }
 
 @Composable

--- a/app/src/main/java/com/example/ratemate/survey/CreateSurveyScreen.kt
+++ b/app/src/main/java/com/example/ratemate/survey/CreateSurveyScreen.kt
@@ -1,6 +1,7 @@
 package com.example.ratemate.survey
 
 import android.util.Log
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -185,9 +186,14 @@ fun CreateSurveyScreen(navController: NavHostController) {
                         comments = mutableListOf()
                     )
                     viewModel.addSurvey(surveyData)
-//                    navController.navigate(SurveyNavRoutes.Result.createRoute(surveyData.surveyId)) {
-//                        popUpTo(SurveyNavRoutes.Create.route) { inclusive = true }
-//                    }
+
+                    // 토스트 메시지 표시
+                    Toast.makeText(context, "설문조사 등록이 완료되었습니다", Toast.LENGTH_SHORT).show()
+
+                    // 모든 입력 필드 초기화
+                    surveyTitle = ""
+                    questionsList.clear()
+                    validateForm()
                 },
                 enabled = isSubmitEnabled,
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/example/ratemate/survey/SurveyListScreen.kt
+++ b/app/src/main/java/com/example/ratemate/survey/SurveyListScreen.kt
@@ -204,19 +204,10 @@ fun SurveyListScreen(navController: NavController) {
 
 @Composable
 fun SurveyItem(survey: SurveyV2, navController: NavController) {
-    val auth = FirebaseAuth.getInstance()
-    val uid = auth.currentUser?.uid
-
     Card(modifier = Modifier
         .fillMaxWidth()
         .padding(vertical = 8.dp)
-        .clickable {
-//            if (uid == survey.creatorId) {
-            navController.navigate("SurveyResult/${survey.surveyId}")
-//            } else {
-//                navController.navigate("answerSurvey/${survey.surveyId}")
-//            }
-        }) {
+        .clickable { navController.navigate("AnswerSurvey/${survey.surveyId}") }) {
         Column(modifier = Modifier.padding(16.dp)) {
             Text(text = survey.title, style = MaterialTheme.typography.headlineSmall)
             Text(text = "작성자: ${survey.creatorId}", style = MaterialTheme.typography.bodyMedium)

--- a/app/src/main/java/com/example/ratemate/survey/SurveyListScreen.kt
+++ b/app/src/main/java/com/example/ratemate/survey/SurveyListScreen.kt
@@ -1,11 +1,35 @@
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -30,7 +54,8 @@ import com.google.firebase.auth.FirebaseAuth
 @Composable
 fun SurveyListScreen(navController: NavController) {
     val surveyRepository = SurveyV2Repository()
-    val surveyViewModel: SurveyV2ViewModel = viewModel(factory = SurveyV2ViewModelFactory(surveyRepository))
+    val surveyViewModel: SurveyV2ViewModel =
+        viewModel(factory = SurveyV2ViewModelFactory(surveyRepository))
     val surveys by surveyViewModel.surveys.collectAsState(initial = emptyList())
 
     val userRepository = UserRepository()
@@ -85,7 +110,11 @@ fun SurveyListScreen(navController: NavController) {
             )
         },
         content = { paddingValues ->
-            Column(modifier = Modifier.padding(paddingValues).padding(16.dp)) {
+            Column(
+                modifier = Modifier
+                    .padding(paddingValues)
+                    .padding(16.dp)
+            ) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically,
@@ -99,14 +128,24 @@ fun SurveyListScreen(navController: NavController) {
                     )
                     Box {
                         IconButton(onClick = { expanded = !expanded }) {
-                            Icon(imageVector = Icons.Default.MoreVert, contentDescription = "정렬", tint = Color.Black)
+                            Icon(
+                                imageVector = Icons.Default.MoreVert,
+                                contentDescription = "정렬",
+                                tint = Color.Black
+                            )
                         }
                         DropdownMenu(
                             expanded = expanded,
                             onDismissRequest = { expanded = false }
                         ) {
                             DropdownMenuItem(
-                                text = { Text("최신순", fontFamily = NotoSansKr, fontWeight = FontWeight.Bold) },
+                                text = {
+                                    Text(
+                                        "최신순",
+                                        fontFamily = NotoSansKr,
+                                        fontWeight = FontWeight.Bold
+                                    )
+                                },
                                 onClick = {
                                     surveyViewModel.sortSurveys(SortType.LATEST)
                                     sortText = "최신순"
@@ -114,7 +153,13 @@ fun SurveyListScreen(navController: NavController) {
                                 }
                             )
                             DropdownMenuItem(
-                                text = { Text("좋아요 많은 순", fontFamily = NotoSansKr, fontWeight = FontWeight.Bold) },
+                                text = {
+                                    Text(
+                                        "좋아요 많은 순",
+                                        fontFamily = NotoSansKr,
+                                        fontWeight = FontWeight.Bold
+                                    )
+                                },
                                 onClick = {
                                     surveyViewModel.sortSurveys(SortType.MOST_LIKED)
                                     sortText = "좋아요 많은 순"
@@ -122,7 +167,13 @@ fun SurveyListScreen(navController: NavController) {
                                 }
                             )
                             DropdownMenuItem(
-                                text = { Text("답변 많은 순", fontFamily = NotoSansKr, fontWeight = FontWeight.Bold) },
+                                text = {
+                                    Text(
+                                        "답변 많은 순",
+                                        fontFamily = NotoSansKr,
+                                        fontWeight = FontWeight.Bold
+                                    )
+                                },
                                 onClick = {
                                     surveyViewModel.sortSurveys(SortType.MOST_RESPONDED)
                                     sortText = "답변 많은 순"
@@ -153,14 +204,26 @@ fun SurveyListScreen(navController: NavController) {
 
 @Composable
 fun SurveyItem(survey: SurveyV2, navController: NavController) {
+    val auth = FirebaseAuth.getInstance()
+    val uid = auth.currentUser?.uid
+
     Card(modifier = Modifier
         .fillMaxWidth()
         .padding(vertical = 8.dp)
-        .clickable { navController.navigate("answerSurvey/${survey.surveyId}") }) {
+        .clickable {
+//            if (uid == survey.creatorId) {
+            navController.navigate("SurveyResult/${survey.surveyId}")
+//            } else {
+//                navController.navigate("answerSurvey/${survey.surveyId}")
+//            }
+        }) {
         Column(modifier = Modifier.padding(16.dp)) {
             Text(text = survey.title, style = MaterialTheme.typography.headlineSmall)
             Text(text = "작성자: ${survey.creatorId}", style = MaterialTheme.typography.bodyMedium)
-            Text(text = "좋아요: ${survey.likes.count}, 답변 수: ${survey.response.size}", style = MaterialTheme.typography.bodySmall)
+            Text(
+                text = "좋아요: ${survey.likes.count}, 답변 수: ${survey.response.size}",
+                style = MaterialTheme.typography.bodySmall
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/ratemate/survey/SurveyNavGraph.kt
+++ b/app/src/main/java/com/example/ratemate/survey/SurveyNavGraph.kt
@@ -1,0 +1,47 @@
+package com.example.ratemate.survey
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import com.example.ratemate.home.HomeNavRoutes
+import com.example.ratemate.home.SurveyResultScreen
+
+sealed class SurveyNavRoutes (val route: String) {
+    object AnswerSurvey: SurveyNavRoutes("AnswerSurvey")
+    object SurveyResult: SurveyNavRoutes("SurveyResult")
+}
+
+@Composable
+fun SurveyNavigationHost(navController: NavHostController, startnavController: NavHostController) {
+    NavHost(navController = navController, startDestination = SurveyNavRoutes.AnswerSurvey.route) {
+        composable(
+            HomeNavRoutes.AnswerSurvey.route + "/{SurveyID}",
+            arguments = listOf(
+                navArgument(name = "SurveyID") {
+                    type = NavType.StringType
+                }
+            )) {
+            AnswerSurveyScreen(
+                navController = startnavController,
+                surveyId = it.arguments?.getString("SurveyID")
+            )
+        }
+
+        composable(
+            HomeNavRoutes.SurveyResult.route + "/{SurveyID}",
+            arguments = listOf(
+                navArgument(name = "SurveyID") {
+                    type = NavType.StringType
+                }
+            )
+        ) {
+            SurveyResultScreen(
+                navController = navController,
+                SurveyID = it.arguments?.getString("SurveyID")
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/ratemate/viewModel/SurveyResultViewModel.kt
+++ b/app/src/main/java/com/example/ratemate/viewModel/SurveyResultViewModel.kt
@@ -1,4 +1,4 @@
-package com.example.ratemate.viewmodel
+package com.example.ratemate.viewModel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider


### PR DESCRIPTION
홈 화면에서 답변 페이지로 이동 안되던 오류 수정했습니다.
답변하기 기능 완료했고 결과 페이지로 이동하기까지 완료했습니다.

앱을 쭉 훑어가면서 QA를 진행해봤을 때 수정되어야할 기능들을 몇가지 정리해봤습니다.

- [ ] bottom bar가 어떤 페이지들에서는 동작하지 않습니다.
- [x] 홈 화면에서 답변 완료한 설문이 반영되지 않습니다.
- [x] 위 문제로 인해 답변 완료했는데 마이페이지의 내 답변 탭에서 확인이 불가하고 이미 답변한 설문에 또 답변이 가능합니다
- [ ] 전체적인 UI 통일성있게 수정하기
- [ ] 댓글쪽에 문제가 몇가지 있습니다. (연속으로 달기 불가, 댓글 수에 반영 안됨, 댓글 달고 다른 페이지 다녀오면 댓글 삭제돼있음)
- [ ] 마이페이지에서 내 설문이나 내 답변 탭을 누르면 그냥 결과 화면 자체로 이동하도록 하는게 좋을 듯 합니다. (top app bar 문제로 인해)
- [ ] 마이페이지 포인트 내역에서 어떤 경로로 포인트 획득했는지가 반영이 안돼있는 것 같습니다.